### PR TITLE
Add Production docker compose and improvements.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# ignore files which have nothing to do in a container.
+.do
+.github
+# we do not care for the git history in the container, saves space.
+.git
+.gitignore
+Caddyfile
+docker-compose*
+Dockerfile
+Makefile
+render.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,6 @@ ADD . /app
 # Compile the main app so that it doesn't need to be compiled each startup/entry.
 RUN deno cache --reload main.ts
 
+ENTRYPOINT [ "sh", "entrypoint.sh" ]
+
 CMD ["run", "--allow-all", "main.ts"]

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,13 @@ crons/cleanup:
 .PHONY: exec-db
 exec-db:
 	docker exec -it -u postgres $(shell basename $(CURDIR))_postgresql_1 psql
+
+prod-up-d:
+	docker compose -f docker-compose.prod.yml up -d --force-recreate --remove-orphans
+
+prod-up:
+	docker compose -f docker-compose.prod.yml up --force-recreate --remove-orphans
+	docker compose -f docker-compose.prod.yml logs -f
+
+prod-down:
+	docker compose -f docker-compose.prod.yml down

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,56 @@
+services:
+  budgetzen_db:
+    container_name: budgetzen_db
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=${POSTGRESQL_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD:-fake}
+      - POSTGRES_DB=${POSTGRESQL_DBNAME:-budgetzen}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    networks:
+      - budgetzen
+    restart: unless-stopped
+
+  budgetzen_web:
+    container_name: budgetzen_web
+    image: ghcr.io/brunobernardino/budgetzen-web:main
+    # If you want to build the image locally, uncomment the
+    # following lines and comment the image line above
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    ports:
+      - ${PORT:-8000}:8000
+    networks:
+      - budgetzen
+    restart: unless-stopped
+    environment:
+    - BASE_URL=${BASE_URL:-http://localhost:${PORT:-8000}}
+    - POSTGRESQL_HOST=${POSTGRESQL_HOST:-budgetzen_db}
+    - POSTGRESQL_USER=${POSTGRESQL_USER:-postgres}
+    - POSTGRESQL_PASSWORD=${POSTGRESQL_PASSWORD:-fake}
+    - POSTGRESQL_DBNAME=${POSTGRESQL_DBNAME:-budgetzen}
+    - POSTGRESQL_PORT=${POSTGRESQL_PORT:-5432}
+    - POSTGRESQL_CAFILE=${POSTGRESQL_CAFILE:-}
+    - BREVO_API_KEY=${BREVO_API_KEY:-}
+    - STRIPE_API_KEY=${STRIPE_API_KEY:-}
+    
+    # any non-empty value will be considered true
+    - IS_UNSAFE_SELF_HOSTED="true"
+
+    depends_on:
+      - budgetzen_db
+
+networks:
+  budgetzen:
+
+volumes:
+  pgdata:
+    driver: local

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+echo '
+-------------------------------------
+BudgetZen - A simple budgeting app by Bruno Bernardino
+
+https://github.com/BrunoBernardino/budgetzen-web
+-------------------------------------'
+
+echo "**** Run migrations ****"
+deno run --allow-net --allow-read --allow-env migrate-db.ts
+
+echo "**** Setup complete, starting the server. ****"
+deno run --allow-all main.ts


### PR DESCRIPTION
Fixes #6

After some trial and errors I got it to run.

This PR contains the followings:

- addied a `.dockerignore`. This allows us to ignore the `.git` and other which are not needed in the container.
Making it smaller.
- added an entrypoint.sh file. This makes sure that whenever the container is started, the migrations are run.
This solves the issue of having to run the migrations in some way when deploying from docker compose.
- added a bunch of commands in the makefile for simple quick local deployment.